### PR TITLE
Set default lang for CDTS interpolation

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ site.lang | default: 'en-Ca' }}" xmlns="http://www.w3.org/1999/xhtml" class="no-js" dir="ltr">
+<html lang="{{ site.lang | default: 'en' }}" xmlns="http://www.w3.org/1999/xhtml" class="no-js" dir="ltr">
   <head>
     <meta charset='utf-8'>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/_layouts/no-banner.html
+++ b/_layouts/no-banner.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ site.lang | default: 'en-Ca' }}" xmlns="http://www.w3.org/1999/xhtml" class="no-js" dir="ltr">
+<html lang="{{ site.lang | default: 'en' }}" xmlns="http://www.w3.org/1999/xhtml" class="no-js" dir="ltr">
   <head>
     <meta charset='utf-8'>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
CDTS fails to load the correct scripts if the `lang="en"` is set to something else. 

This fixes #114 