### PR TITLE
Create CloudOperations

### DIFF
--- a/docs/_guides/CloudOperations
+++ b/docs/_guides/CloudOperations
@@ -1,0 +1,9 @@
+---
+title: Cloud Operations
+layout: default
+category: ESDC Processes
+summary: Cloud Operations team for cloud related requests (Request environments, Cloud to Ground (SCED), Service Principal, etc.)
+date: 2022-09-09
+---
+
+Visit the [Cloud Operations Sharepoint site](https://014gc.sharepoint.com/sites/OI-CO) to view the latest processes for any Cloud related needs (Request environments, Cloud to Ground (SCED), Service Principal, etc.). 


### PR DESCRIPTION
Create a an item (Cloud Operations) under ESDC processes.

Edit: I think we might have to add another "tab". The guide template requires navigation to another page but in this case it's not required. Why go to another page when all that I need is a "one liner" and a hyper link to a sharepoint site.